### PR TITLE
Issues22 cap

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -51,8 +51,8 @@ public:
 	void SetFd(int fd);
 	void SetNickname(const std::string &nick);
 	void SetIsAuthenticated();
-	void SetIsWelcome(bool iswelcome);
-	void SetIsConnected();
+	void SetIsWelcome(bool is_welcome);
+	void SetIsConnected(bool is_connected);
 	void SetIPAddress(const std::string& ipaddress);
 	void AddMessage(const std::string &message);
 

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -46,12 +46,13 @@ namespace Command{
     void NICK(Client &client, std::map<std::string, int> &map_nick_fd, const Message &message);
     void KICK(Client &client, Server *server, const Message &message);
     void USER(Client &client, const Message &message);
-	void CAP(Client &client, std::vector<struct pollfd> &pollfds, std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd);
+	void CAP(Client &client, std::vector<struct pollfd> &pollfds,
+			 std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd);
 };
 
 void SendMessage(int fd, const std::string &message, int flag);
 void SendWelcomeMessage(const Client &client);
-void clearClientInfo(
+void ClearClientInfo(
 		Client &client,
 		std::vector<struct pollfd> &pollfds,
 		std::map<int, Client> &users,

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -18,6 +18,12 @@ class Message;
 // ニックネーム変更メッセージ
 #define RPL_NICK(oldnick, newnick) ":" + oldnick + " NICK :" + newnick + "\r\n"
 
+// Commandのメッセージ
+#define RPL_NONE(message) ":ft_irc 300 * :" + message + "\r\n"
+
+// CAP LSメッセージ (CAPコマンドのレスポンス)
+#define CAP_LS ":ft_irc CAP * LS\r\n"
+
 // エラーメッセージ
 #define ERR_UNKNOWNCOMMAND(nick, command) ":ft_irc 421 " + nick + " " + command + " :Unknown command\r\n"
 #define ERR_ERRONEUSNICKNAME(nick) ":ft_irc 432 " + nick + " :Erroneus nickname\r\n"
@@ -30,17 +36,26 @@ class Message;
 #define ERR_NOSUCHCHANNEL(nick) "403 " + nick + "#nonexistent :No such channel\r\n"
 #define ERR_NOTONCHANNEL(nick, ch_name) "442 " + nick + " " + ch_name + " :You're not on that channel\r\n"
 #define ERR_USERNOTINCHANNEL(nick, ch_name) "441 kicker " + nick + " " + ch_name + " :They aren't on that channel\r\n"
+#define ERR_PASSWDMISMATCH(nick) "464 " + nick + " :Password incorrect\r\n"
+
+// パスワードエラーメッセージ
+#define PASS_ERROR(host) "ERROR :Closing Link: " + host + "(Bad Password)\r\n"
 
 namespace Command{
     void PASS(Client &client, Server *server, const Message &message);
     void NICK(Client &client, std::map<std::string, int> &map_nick_fd, const Message &message);
     void KICK(Client &client, Server *server, const Message &message);
     void USER(Client &client, const Message &message);
+	void CAP(Client &client, std::vector<struct pollfd> &pollfds, std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd);
 };
 
-// void PASS(Client &client, Server *server, const Message &message);
-// void NICK(Client &client, std::map<std::string, int> &map_nick_fd, const Message &message);
 void SendMessage(int fd, const std::string &message, int flag);
 void SendWelcomeMessage(const Client &client);
+void clearClientInfo(
+		Client &client,
+		std::vector<struct pollfd> &pollfds,
+		std::map<int, Client> &users,
+		std::map<std::string, int> &nick_to_fd
+);
 
 #endif

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -10,7 +10,7 @@ class Client;
 class Message;
 
 // Welcomeメッセージ(001 ~ 004)
-#define RPL_WELCOME(nick) ":ft_irc 001 " + nick + " :Welcome to the Internet Relay Chat Network " + nick + "\r\n"
+#define RPL_WELCOME(nick) ":ft_irc 001 " + nick + " :Welcome to the Internet Relay Chat Network \r\n"
 #define RPL_YOURHOST(nick) ":ft_irc 002 " + nick + " :Your host is ft_irc, running version 1.0\r\n"
 #define RPL_CREATED(nick) ":ft_irc 003 " + nick + " :This server was created in C++ [Sunday, June 16, 2024]\r\n"
 #define RPL_MYINFO(nick) ":ft_irc 004 " + nick + " :FT_IRC 1.0 contributes: oaoba yushimom stakimot \r\n"

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -47,7 +47,8 @@ namespace Command{
     void KICK(Client &client, Server *server, const Message &message);
     void USER(Client &client, const Message &message);
 	void CAP(Client &client, std::vector<struct pollfd> &pollfds,
-			 std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd);
+			 std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd,
+			 const Message &message);
 };
 
 void SendMessage(int fd, const std::string &message, int flag);

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -83,9 +83,6 @@ public:
 	/* setter */
 	void SetPassword(const std::string &password);
 
-	/* password検証 */
-	bool CheckPassword(const std::string &password) const;
-
 	/* Command */
 	void ExecuteCommand(int fd, const Message &message);
 };

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -108,12 +108,12 @@ void Client::SetNickname(const std::string &nick) {
 	this->nickname_ = nick;
 }
 
-void Client::SetIsWelcome(bool iswelcome) {
-	this->is_welcome_ = iswelcome;
+void Client::SetIsWelcome(bool is_welcome) {
+	this->is_welcome_ = is_welcome;
 }
 
-void Client::SetIsConnected() {
-	this->is_connected_ = true;
+void Client::SetIsConnected(bool is_connected) {
+	this->is_connected_ = is_connected;
 }
 
 void Client::SetIPAddress(const std::string &ipaddress) {

--- a/srcs/command/CAP.cpp
+++ b/srcs/command/CAP.cpp
@@ -1,0 +1,63 @@
+#include "Command.hpp"
+
+void clearClientInfo(
+		Client &client,
+		std::vector<struct pollfd> &pollfds,
+		std::map<int, Client> &users,
+		std::map<std::string, int> &nick_to_fd
+);
+
+/* CAPコマンド(クライアントがサポートする機能をリストアップする)
+ * 引数1 -> クライアント
+ * 引数2 -> pollfd構造体のvector
+ * 引数3 -> ユーザーのmap
+ * 引数4 -> ニックネームとファイルディスクリプタのmap */
+void CAP(Client &client, std::vector<struct pollfd> &pollfds,
+		std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd) {
+	const Message &message = client.GetMessage();
+	const std::string nick = client.GetNickname();
+	const int &fd = client.GetFd();
+
+	if (message.GetParams()[0] == "LS")
+		SendMessage(fd, CAP_LS, 0);
+	else if (message.GetParams()[0] == "END") {
+		if (client.GetIsAuthenticated() == false) {
+			SendMessage(fd, ERR_PASSWDMISMATCH(nick), 0);
+			SendMessage(fd, PASS_ERROR(client.GetHostname()), 0);
+			clearClientInfo(client, pollfds, users, nick_to_fd);
+			return;
+		}
+		SendMessage(fd, RPL_NONE((std::string) "Authenticated ..."), 0);
+		if (client.GetIsNick())
+		{
+			client.SetIsConnected(true);
+			SendWelcomeMessage(client);
+		}
+	}
+}
+
+
+/* クライアントのデータを削除する関数
+ * 引数1 -> クライアントのソケットファイルディスクリプタ
+ * 引数2 -> 送信するメッセージ
+ * 引数3 -> 送信するメッセージのサイズ */
+void clearClientInfo(
+		Client &client,
+		std::vector<struct pollfd> &pollfds,
+		std::map<int, Client> &users,
+		std::map<std::string, int> &nick_to_fd
+) {
+	const std::string nick = client.GetNickname();
+
+	for (std::vector<struct pollfd>::iterator it = pollfds.begin(); it != pollfds.end(); it++)
+	{
+		if (client.GetFd() == it->fd)
+		{
+			pollfds.erase(it);
+			break;
+		}
+	}
+	users.erase(client.GetFd());
+	nick_to_fd.erase(nick);
+	close(client.GetFd());
+}

--- a/srcs/command/CAP.cpp
+++ b/srcs/command/CAP.cpp
@@ -1,6 +1,6 @@
 #include "Command.hpp"
 
-void clearClientInfo(
+void ClearClientInfo(
 		Client &client,
 		std::vector<struct pollfd> &pollfds,
 		std::map<int, Client> &users,
@@ -12,7 +12,7 @@ void clearClientInfo(
  * 引数2 -> pollfd構造体のvector
  * 引数3 -> ユーザーのmap
  * 引数4 -> ニックネームとファイルディスクリプタのmap */
-void CAP(Client &client, std::vector<struct pollfd> &pollfds,
+void Command::CAP(Client &client, std::vector<struct pollfd> &pollfds,
 		std::map<int, Client> &users, std::map<std::string, int> &nick_to_fd) {
 	const Message &message = client.GetMessage();
 	const std::string nick = client.GetNickname();
@@ -24,7 +24,7 @@ void CAP(Client &client, std::vector<struct pollfd> &pollfds,
 		if (client.GetIsAuthenticated() == false) {
 			SendMessage(fd, ERR_PASSWDMISMATCH(nick), 0);
 			SendMessage(fd, PASS_ERROR(client.GetHostname()), 0);
-			clearClientInfo(client, pollfds, users, nick_to_fd);
+			ClearClientInfo(client, pollfds, users, nick_to_fd);
 			return;
 		}
 		SendMessage(fd, RPL_NONE((std::string) "Authenticated ..."), 0);
@@ -41,7 +41,7 @@ void CAP(Client &client, std::vector<struct pollfd> &pollfds,
  * 引数1 -> クライアントのソケットファイルディスクリプタ
  * 引数2 -> 送信するメッセージ
  * 引数3 -> 送信するメッセージのサイズ */
-void clearClientInfo(
+void ClearClientInfo(
 		Client &client,
 		std::vector<struct pollfd> &pollfds,
 		std::map<int, Client> &users,
@@ -49,10 +49,8 @@ void clearClientInfo(
 ) {
 	const std::string nick = client.GetNickname();
 
-	for (std::vector<struct pollfd>::iterator it = pollfds.begin(); it != pollfds.end(); it++)
-	{
-		if (client.GetFd() == it->fd)
-		{
+	for (std::vector<struct pollfd>::iterator it = pollfds.begin(); it != pollfds.end(); it++) {
+		if (client.GetFd() == it->fd) {
 			pollfds.erase(it);
 			break;
 		}

--- a/srcs/command/CAP.cpp
+++ b/srcs/command/CAP.cpp
@@ -20,14 +20,8 @@ void Command::CAP(Client &client, std::vector<struct pollfd> &pollfds,
 	const std::string nick = client.GetNickname();
 	const int &fd = client.GetFd();
 
-	if (params.empty()) {
-		SendMessage(fd, std::string(YELLOW) + "CAP command requires parameters." + std::string(STOP), 0);
-		return;
-	}
-
-	if (params[0] == "LS") {
+	if (params[0] == "LS")
 		SendMessage(fd, CAP_LS, 0);
-	}
 	else if (params[0] == "END") {
 		if (!client.GetIsAuthenticated()) {
 			SendMessage(fd, ERR_PASSWDMISMATCH(nick), 0);

--- a/srcs/command/USER.cpp
+++ b/srcs/command/USER.cpp
@@ -17,11 +17,5 @@ void Command::USER(Client &client, const Message &message) {
 		client.SetHostname(message.GetParams()[1]);
 		client.SetServername(message.GetParams()[2]);
 		client.SetRealname(message.GetParams()[3]);
-
-		// ログ出力
-		std::cout << "Username: " << client.GetUsername() << std::endl;
-		std::cout << "Hostname: " << client.GetHostname() << std::endl;
-		std::cout << "Servername: " << client.GetServername() << std::endl;
-		std::cout << "Realname: " << client.GetRealname() << std::endl;
 	}
 }

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -65,6 +65,10 @@ void Server::ChatFlow(int fd) {
 
 	// マップからクライアントを取得
 	Client &user = users_[fd];
+	std::cout << "-------------Client Message-------------" << std::endl;
+	std::cout << "client fd: [" << fd << "]" << std::endl;
+	std::cout << "client : " << received_data << std::endl;
+	std::cout << "----------------------------------------" << std::endl;
 	// 受け取ったデータをクライアントのメッセージバッファに追加
 	user.AddMessage(std::string(received_data));
 	//　クライアントのメッセージバッファを取得
@@ -100,19 +104,19 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 	std::string cmd = message.GetCommand();
 	const std::vector<std::string> &params = message.GetParams();
 	// map_nick_fdにはニックネームとソケットファイルディスクリプタのマップが格納されている
-
 	if (!client.GetIsAuthenticated()) {
 		if (cmd == "PASS")
 			Command::PASS(client, this, message);
 		else
 			SendMessage(fd, std::string(YELLOW) + ERR_NOTREGISTERED(client.GetNickname()) + std::string(STOP), 0);
 		return ;
-	}
 
 	/* コマンドの前後の空白を取り除く */
 	cmd = Trim(cmd);
 
-	if (cmd == "NICK")
+	if (cmd == "CAP")
+		Command::CAP(client, fds_, users_, map_nick_fd_);
+	else if (cmd == "NICK")
 		Command::NICK(client, map_nick_fd_, message);
 	else if (cmd == "USER")
 		if (client.GetIsUserSet())
@@ -123,6 +127,7 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 		}
 	else
 		SendMessage(fd, std::string(YELLOW) + ERR_UNKNOWNCOMMAND(client.GetNickname(), cmd) + std::string(STOP), 0);
+	}
 }
 
 

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -98,24 +98,34 @@ void Server::ChatFlow(int fd) {
 
 
 /* Commandを処理する関数
- * 引数1 -> クライアントのソケットファイルディスクリプタ*/
+ * 引数1 -> クライアントのソケットファイルディスクリプタ
+ * 引数2 -> メッセージオブジェクト*/
 void Server::ExecuteCommand(int fd, const Message &message) {
 	Client &client = users_[fd];
 	std::string cmd = message.GetCommand();
 	const std::vector<std::string> &params = message.GetParams();
 	// map_nick_fdにはニックネームとソケットファイルディスクリプタのマップが格納されている
-	if (!client.GetIsAuthenticated()) {
-		if (cmd == "PASS")
-			Command::PASS(client, this, message);
-		else
-			SendMessage(fd, std::string(YELLOW) + ERR_NOTREGISTERED(client.GetNickname()) + std::string(STOP), 0);
-		return ;
+
+	if (client.GetIsWelcome() == false && client.GetIsConnected() == false &&
+			cmd != "NICK" && cmd != "USER" && cmd != "CAP") {
+//		ClearClientInfo(client, fds_, users_, map_nick_fd_);
+// 		⇧　ERROR: AddressSanitizer: heap-use-after-free on addressが出てしまうので一旦コメントアウト
+		return;
+	}
+	else if (client.GetIsWelcome() == false && client.GetIsConnected() == false && cmd == "NICK") {
+		Command::NICK(client, map_nick_fd_, message);
+		if (client.GetIsNick())
+			SendWelcomeMessage(client);
+		return;
+	}
 
 	/* コマンドの前後の空白を取り除く */
 	cmd = Trim(cmd);
 
 	if (cmd == "CAP")
 		Command::CAP(client, fds_, users_, map_nick_fd_);
+	else if (cmd == "PASS")
+		Command::PASS(client, this, password_);
 	else if (cmd == "NICK")
 		Command::NICK(client, map_nick_fd_, message);
 	else if (cmd == "USER")
@@ -127,9 +137,7 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 		}
 	else
 		SendMessage(fd, std::string(YELLOW) + ERR_UNKNOWNCOMMAND(client.GetNickname(), cmd) + std::string(STOP), 0);
-	}
 }
-
 
 /* クライアントにデータを送信する関数
  * 引数1 -> クライアントのソケットファイルディスクリプタ
@@ -174,14 +182,6 @@ void Server::CloseFds() {
 		// socketが閉じられたことを記録
 		server_socket_fd_ = -1;
 	}
-}
-
-
-/* passwordを検証する関数
- * 引数1 -> 入力されたパスワード
- * 戻り値 -> パスワードが正しい場合はtrue、それ以外はfalse*/
-bool Server::CheckPassword(const std::string &password) const {
-	return password == this->password_;
 }
 
 

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -106,35 +106,40 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 	const std::vector<std::string> &params = message.GetParams();
 	// map_nick_fdにはニックネームとソケットファイルディスクリプタのマップが格納されている
 
-	if (client.GetIsWelcome() == false && client.GetIsConnected() == false &&
-			cmd != "NICK" && cmd != "USER" && cmd != "CAP") {
+	// 初期接続時に許可されるコマンドの制限
+	if (!client.GetIsConnected() && cmd != "NICK" && cmd != "USER" && cmd != "CAP") {
+		SendMessage(fd, std::string(YELLOW) + "You must register first (NICK and USER commands)." + std::string(STOP), 0);
 //		ClearClientInfo(client, fds_, users_, map_nick_fd_);
 // 		⇧　ERROR: AddressSanitizer: heap-use-after-free on addressが出てしまうので一旦コメントアウト
-		return;
-	}
-	else if (client.GetIsWelcome() == false && client.GetIsConnected() == false && cmd == "NICK") {
-		Command::NICK(client, map_nick_fd_, message);
-		if (client.GetIsNick())
-			SendWelcomeMessage(client);
 		return;
 	}
 
 	/* コマンドの前後の空白を取り除く */
 	cmd = Trim(cmd);
 
-	if (cmd == "CAP")
-		Command::CAP(client, fds_, users_, map_nick_fd_);
-	else if (cmd == "PASS")
-		Command::PASS(client, this, password_);
-	else if (cmd == "NICK")
+	if (cmd == "NICK") {
 		Command::NICK(client, map_nick_fd_, message);
-	else if (cmd == "USER")
+		if (client.GetIsNick() && client.GetIsUserSet() && !client.GetIsWelcome()) {
+			SendWelcomeMessage(client);
+			client.SetIsConnected(true);
+		}
+	} else if (cmd == "USER") {
 		if (client.GetIsUserSet())
 			SendMessage(fd, std::string(YELLOW) + ERR_ALREADYREGISTERED(client.GetNickname()) + std::string(STOP), 0);
 		else {
 			Command::USER(client, message);
 			client.SetIsUserSet(true);
+			if (client.GetIsNick() && !client.GetIsWelcome()) {
+				SendWelcomeMessage(client);
+				client.SetIsConnected(true);
+				client.SetIsWelcome(true);
+			}
 		}
+	}
+	else if (cmd == "CAP")
+		Command::CAP(client, fds_, users_, map_nick_fd_, message);
+	else if (cmd == "PASS")
+		Command::PASS(client, this, password_);
 	else
 		SendMessage(fd, std::string(YELLOW) + ERR_UNKNOWNCOMMAND(client.GetNickname(), cmd) + std::string(STOP), 0);
 }

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -110,7 +110,6 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 	if (!client.GetIsConnected() && cmd != "NICK" && cmd != "USER" && cmd != "CAP") {
 		SendMessage(fd, std::string(YELLOW) + "You must register first (NICK and USER commands)." + std::string(STOP), 0);
 //		ClearClientInfo(client, fds_, users_, map_nick_fd_);
-// 		⇧　ERROR: AddressSanitizer: heap-use-after-free on addressが出てしまうので一旦コメントアウト
 		return;
 	}
 


### PR DESCRIPTION
<やったこと>
・CAPコマンドの実装
（clientがserverに対して利用可能な拡張機能のリストを要求した際にserverから送られるレスポンス）

<確認方法>
Irssiを使用。Irssi起動時に自動的に以下の順序でコマンドが送信されてくる

1. `CAP LS`：サーバーがサポートするCAPABILITIESを問い合わせ
2. `CAP END`：CAPABILITIES交渉の終了をサーバーに通知
3. `NICK`：クライアントのニックネームを設定
4. `USER`：クライアントのユーザー情報を設定

この順序で、server側にログが出力されるようにした。

<相談>
上記の内容がserver側のログには出てくるが、irssi側のログが下記のようなものなので、CAPコマンドによって上手くserverとclientは接続されるものの、拡張機能がclientに接続されていない可能性がある。なので、一旦プルリク送ってmergeした後に機能追加する可能性もあります。
```
20:42 -!- Irssi: Looking up localhost
20:42 -!- Irssi: Connecting to localhost [127.0.0.1] port 8080
20:42 Waiting for CAP LS response...
20:42 -!- Irssi: Connection to localhost established
20:42 -!- Capabilities supported: 

```