### PR TITLE
Issue29 fix join

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <algorithm>
 
-
 #include "Client.hpp"
 
 class Client;

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -50,9 +50,10 @@ class Message;
 #define ERR_CHANNELISFULL(nick, ch_name) "ERR_CHANNELISFULL (471) " + nick + " "+ ch_name + " :Cannot join channel (+l)\r\n"
 #define ERR_BADCHANNELKEY(nick, ch_name)  "ERR_BADCHANNELKEY (475) " + nick + " " + ch_name + " :Cannot join channel (+k)\r\n"
 #define ERR_INVITEONLYCHAN(nick, ch_name) "ERR_INVITEONLYCHAN (473)  " + nick + " " + ch_name + " :Cannot join channel (+l)\r\n"
+#define ERR_BADCHANMASK(nick, ch_name) ":server 476 " + nick + " " + ch_name + " :Bad Channel Mask\r\n"
 
 #define INVITE_SUCCESS(nick,user,ip, invited, ch_name) ":"+nick+"!"+user+"@"+ip+" INVITE "+invited+" :" + ch_name+ "\r\n"
-#define INVITED_MSG(inviter, invited, ch_name) ":ft_irc 341 "+inviter+" "+invited+" "+ch_name
+#define INVITED_MSG(inviter, invited, ch_name) ":ft_irc 341 "+inviter+" "+invited+" "+ch_name + "\r\n"
 // #define ERR_NEEDMOREPARAMS(nick) ":ft_irc 461 " + nick + " INVITE :Not enough parameters\r\n"
 // #define ERR_NOSUCHNICK(inviter, invited) ":ft_irc 401 "+inviter+" "+invited+" :No such nick/channel\r\n"
 // #define ERR_NOTONCHANNEL(inviter, ch_name) ":ft_irc 442 "+inviter+" "+ch_name+" :You're not on that channel\r\n"

--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -39,14 +39,14 @@ class Message;
 #define ERR_NOTONCHANNEL(nick, ch_name) "442 " + nick + " " + ch_name + " :You're not on that channel\r\n"
 #define ERR_USERNOTINCHANNEL(nick, ch_name) "441 kicker " + nick + " " + ch_name + " :They aren't on that channel\r\n"
 #define ERR_PASSWDMISMATCH(nick) "464 " + nick + " :Password incorrect\r\n"
+#define ERR_CHANNELISFULL(nick, ch_name) "ERR_CHANNELISFULL (471) " + nick + " "+ ch_name + " :Cannot join channel (+l)\r\n"
+#define ERR_BADCHANNELKEY(nick, ch_name)  "ERR_BADCHANNELKEY (475) " + nick + " " + ch_name + " :Cannot join channel (+k)\r\n"
+#define ERR_INVITEONLYCHAN(nick, ch_name) "ERR_INVITEONLYCHAN (473)  " + nick + " " + ch_name + " :Cannot join channel (+l)\r\n"
 
 // パスワードエラーメッセージ
 #define PASS_ERROR(host) "ERROR :Closing Link: " + host + "(Bad Password)\r\n"
 
 #define JOIN_SCCESS_MSG(nick, user, ch_name) nick + "! " + user + "JOIN : " + ch_name + "\r\n"
-#define ERR_CHANNELISFULL(nick, ch_name) "ERR_CHANNELISFULL (471) " + nick + " "+ ch_name + " :Cannot join channel (+l)\r\n"
-#define ERR_BADCHANNELKEY(nick, ch_name)  "ERR_BADCHANNELKEY (475) " + nick + " " + ch_name + " :Cannot join channel (+k)\r\n"
-#define ERR_INVITEONLYCHAN(nick, ch_name) "ERR_INVITEONLYCHAN (473)  " + nick + " " + ch_name + " :Cannot join channel (+l)\r\n"
 
 namespace Command{
     void PASS(Client &client, Server *server, const Message &message);

--- a/srcs/command/JOIN.cpp
+++ b/srcs/command/JOIN.cpp
@@ -176,6 +176,7 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
             }
         }catch(const std::exception& e){
             std::cerr << "Exception caught: " << e.what() << std::endl;
+            SendMessage(client.GetFd(), "Error\n", 0);
             return;
         }
     }

--- a/srcs/command/JOIN.cpp
+++ b/srcs/command/JOIN.cpp
@@ -127,7 +127,8 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
                 msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
             }
         }catch(const std::exception& e){
-            std::cerr << "Exception caught: " << e.what() << std::endl;
+            msg_to_c = ERR_BADCHANMASK(client.GetNickname(), ch_name);
+            SendMessage(client.GetFd(), msg_to_c, 0);
             return;
         }
 
@@ -176,8 +177,8 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
                     // ch->SetMode(CM_Key);
             }
         }catch(const std::exception& e){
-            std::cerr << "Exception caught: " << e.what() << std::endl;
-            SendMessage(client.GetFd(), "Error\n", 0);
+            msg_to_c = ERR_BADCHANMASK(client.GetNickname(), ch_name);
+            SendMessage(client.GetFd(), msg_to_c, 0);
             return;
         }
     }

--- a/srcs/command/JOIN.cpp
+++ b/srcs/command/JOIN.cpp
@@ -1,12 +1,84 @@
 #include "Command.hpp"
 #include "Message.hpp"
 
+void show_topic(Channel *ch, const std::string &nick, std::string &msg_to_c){
+    if (ch->GetTopic().empty()){
+        msg_to_c += ":ft_irc 331 " + nick + " " + ch->GetName() + " : No topic is set" + "\n";
+    }
+    else{
+        msg_to_c += ":ft_irc 332 " + nick + " " + ch->GetName() + " :" + ch->GetTopic() + "\n";
+    }
+}
+
+void show_channel_member(Channel *ch, const std::string &nick, std::string &msg_to_c){
+    std::map<Client*, User_Priv>::iterator iter = ch->users_.begin();
+
+    msg_to_c += ":server 353 " + nick + " = " + ch->GetName() + " :" ;
+    while(iter != ch->users_.end()){
+        msg_to_c += iter->first->GetNickname() + " ";
+        iter++;
+    }
+    msg_to_c += "\n:server 366 " + nick + " " + ch->GetName() + " :End of list";
+}
+
+void join_without_key(Channel *ch, Client &client, std::string& msg_to_c){
+
+    if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
+        msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
+    }
+    else if(ch->CheckMode(CM_Key)){ //エラー２keyが必要
+        msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
+    }
+    else if(ch->CheckMode(CM_Invite)){
+        if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
+            msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
+        }
+        else{
+            msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+            ch->AddUserAsN(client);
+        }
+    }
+    else{
+        msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+        ch->AddUserAsN(client);
+    }
+}
+
+
+void join_with_key(Channel *ch, Client &client, std::string& msg_to_c, const std::string& key){
+    if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
+        msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
+    }
+    else if(ch->CheckMode(CM_Key)){
+        if(ch->GetKey() != key){ //エラー２keyが一致しない
+            msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
+        }else{
+            ch->AddUserAsN(client);
+        }
+    }
+    else if(ch->CheckMode(CM_Invite)){
+        if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
+            msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
+        }
+        else{
+            msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+            ch->AddUserAsN(client);
+        }
+    }
+    else{
+        msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+            ch->AddUserAsN(client);
+    }
+}
+
+
 // JOIN コマンドの処理をする関数
 // 1: クライアント情報
 // 2: Server情報
 // 3: 受け取ったメッセージ
 void Command::JOIN(Client &client, Server *server, const Message &message)
 {
+    Channel* ch;
     const std::vector<std::string> msg = message.GetParams();
     if(msg.size() < 1){
         return ;
@@ -22,29 +94,30 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
         try{
             if(server->IsChannel(ch_name)){ //チャンネルが存在するとき
                 // 指定されているチャンネルの取得
-                Channel* ch = server->GetChannel(ch_name);
-                if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
-                    msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
-                }
-                else if(ch->CheckMode(CM_Key)){ //エラー２keyが必要
-                    msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
-                }
-                else if(ch->CheckMode(CM_Invite)){
-                    if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
-                        msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
-                    }
-                    else{
-                        msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
-                        ch->AddUserAsN(client);
-                    }
-                }
-                else{
-                    msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
-                    ch->AddUserAsN(client);
-                }
+                ch = server->GetChannel(ch_name);
+                join_without_key(ch, client, msg_to_c);
+                // if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
+                //     msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
+                // }
+                // else if(ch->CheckMode(CM_Key)){ //エラー２keyが必要
+                //     msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
+                // }
+                // else if(ch->CheckMode(CM_Invite)){
+                //     if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
+                //         msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
+                //     }
+                //     else{
+                //         msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+                //         ch->AddUserAsN(client);
+                //     }
+                // }
+                // else{
+                //     msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+                //     ch->AddUserAsN(client);
+                // }
             }
             else{ // チャンネルが存在しないとき
-                Channel* ch = server->CreateChannel(ch_name);
+                ch = server->CreateChannel(ch_name);
                 if(!ch){
                     return;
                 }else{
@@ -63,33 +136,34 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
             const std::string key = msg[1];
             if(server->IsChannel(ch_name)){ //チャンネルが存在するとき
                 // 指定されているチャンネルの取得
-                Channel* ch = server->GetChannel(ch_name);
-                if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
-                    msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
-                }
-                else if(ch->CheckMode(CM_Key)){
-                    if(ch->GetKey() != key){ //エラー２keyが一致しない
-                        msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
-                    }else{
-                        ch->AddUserAsN(client);
-                    }
-                }
-                else if(ch->CheckMode(CM_Invite)){
-                    if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
-                        msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
-                    }
-                    else{
-                        msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
-                        ch->AddUserAsN(client);
-                    }
-                }
-                else{
-                    msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
-                        ch->AddUserAsN(client);
-                }
+                ch = server->GetChannel(ch_name);
+                join_with_key(ch, client, msg_to_c, key);
+                // if(ch->GetLimit() <= ch->users_.size()){ // エラー１すでに満員
+                //     msg_to_c = ERR_CHANNELISFULL(client.GetNickname(), ch->GetName());
+                // }
+                // else if(ch->CheckMode(CM_Key)){
+                //     if(ch->GetKey() != key){ //エラー２keyが一致しない
+                //         msg_to_c = ERR_BADCHANNELKEY(client.GetNickname(), ch->GetName());
+                //     }else{
+                //         ch->AddUserAsN(client);
+                //     }
+                // }
+                // else if(ch->CheckMode(CM_Invite)){
+                //     if(ch->IsInvited(client.GetNickname()) == false){ //エラー３招待が必要
+                //         msg_to_c = ERR_INVITEONLYCHAN(client.GetNickname(), ch->GetName());
+                //     }
+                //     else{
+                //         msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+                //         ch->AddUserAsN(client);
+                //     }
+                // }
+                // else{
+                //     msg_to_c = JOIN_SCCESS_MSG(client.GetNickname(),client.GetUsername(), ch->GetName());
+                //         ch->AddUserAsN(client);
+                // }
             }
             else{
-                Channel* ch = server->CreateChannel(ch_name);
+                ch = server->CreateChannel(ch_name);
                 msg_to_c = client.GetNickname() +"! JOIN :" + ch->GetName();
                 if(!ch){
                     return ;
@@ -105,5 +179,7 @@ void Command::JOIN(Client &client, Server *server, const Message &message)
             return;
         }
     }
+    show_topic(ch,client.GetNickname(), msg_to_c);
+    show_channel_member(ch, client.GetNickname(), msg_to_c);
     SendMessage(client.GetFd(), msg_to_c, 0);
 }


### PR DESCRIPTION
＜変更点＞

- チェンネル名が＃で始まらないときのエラーをクライアントに表示させる
- チャンネルに参加したしたときにトピックとメンバーが表示される


＜テスト方法＞
1. `make`
2. `./ircserve port password`
例）./ircserv 8080 a
3. 別ターミナルで `nc localhost 8080  x2` 
4. `NICK <nickname>  x2`
5. `JOIN <channel>`
例）JOIN test
  (先頭が＃以外で始まるチャンネルを作成しようとするとBad Channel Maskのエラーがクライアントに出力される)
6. user1 `JOIN <#channel>`
7. user1`TOPIC <topic>`
8.  user2 `JOIN <#channel>`
(user2 がuser1と同じチャンネルにjoinしたときに、チャンネルトピックとチャンネルメンバーが表示される)