### PR TITLE
Issue42 welcome message

### DIFF
--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -80,7 +80,7 @@ namespace Command{
 };
 
 void SendMessage(int fd, const std::string &message, int flag);
-void SendWelcomeMessage(const Client &client);
+void SendWelcomeMessage(Client &client);
 void ClearClientInfo(
 		Client &client,
 		std::vector<struct pollfd> &pollfds,

--- a/srcs/command/CommandReply.cpp
+++ b/srcs/command/CommandReply.cpp
@@ -2,7 +2,7 @@
 
 /* Welcomeメッセージを送信する関数
  * 引数1 -> クライアント */
-void SendWelcomeMessage(const Client &client)
+void SendWelcomeMessage(Client &client)
 {
 	const int &fd = client.GetFd();
 	const std::string &nick = client.GetNickname();
@@ -11,4 +11,6 @@ void SendWelcomeMessage(const Client &client)
 	SendMessage(fd, RPL_YOURHOST(nick), 0);
 	SendMessage(fd, RPL_CREATED(nick), 0);
 	SendMessage(fd, RPL_MYINFO(nick), 0);
+
+	client.SetIsWelcome(true);
 }

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -50,6 +50,9 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 
 	// クライアントが認証済みかどうかに関わらず、クライアントの認証状態を設定
 	client.SetIsAuthenticated();
+
+	// ニックネーム変更メッセージを生成して送信
+	SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
 }
 
 

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -2,7 +2,6 @@
 
 bool NickSize(std::string const &nickname);
 bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_nick_fd);
-bool NickValidCharacters(std::string const &nickname);
 
 /* NICKコマンドの処理を行う関数
  * 引数1 -> クライアント
@@ -25,12 +24,6 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
 		return; // 処理を終了
 	}
-
-	// ニックネームの文字セットが有効かどうかを確認
-//	if (!NickValidCharacters(NewNick)) {
-//		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
-//		return; // 処理を終了
-//	}
 
 	// ニックネームがすでに設定されているかどうかを確認
 	if (NickAlreadySet(NewNick, map_nick_fd)) {
@@ -78,26 +71,3 @@ bool NickSize(std::string const &nickname) {
 bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_nick_fd) {
 	return map_nick_fd[nickname] > 0;
 }
-
-// =========== irssiに繋げた時にerrorになってしまうので、一旦コメントアウトしてる。今後変更するかもしれない。========
-
-/* ニックネームに使用できない文字が含まれていないかを確認する関数
- * 引数1 -> ニックネーム
- * 戻り値 -> ニックネームに使用できない文字が含まれていない場合はtrue, そうでない場合はfalse */
-//bool NickValidCharacters(std::string const &nickname) {
-//	if (nickname.empty())
-//		return false;
-//
-//	// 最初の文字がアルファベットまたは特殊文字かどうかを確認
-//	char first_char = nickname[0];
-//	if (!(isalpha(first_char) || first_char == '[' || first_char == ']' || first_char == '\\' || first_char == '^' || first_char == '_' || first_char == '{' || first_char == '}' || first_char == '|'))
-//		return false;
-//
-//	// それ以降の文字が有効かどうかを確認
-//	for (std::string::const_iterator it = nickname.begin() + 1; it != nickname.end(); ++it) {
-//		char c = *it;
-//		if (!(isalpha(c) || isdigit(c) || c == '-' || c == '[' || c == ']' || c == '\\' || c == '^' || c == '_' || c == '{' || c == '}' || c == '|'))
-//			return false;
-//	}
-//	return true;
-//}

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -7,56 +7,51 @@ bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_
  * 引数1 -> クライアント
  * 引数2 -> サーバーの情報
  * 引数3 -> メッセージ */
-void Command::NICK(Client &client, Server *server,std::map<std::string, int> &map_nick_fd, std::map<std::string, Channel> &server_channels, const Message &message) {
+void Command::NICK(Client &client, Server *server, std::map<std::string, int> &map_nick_fd, std::map<std::string, Channel> &server_channels, const Message &message) {
 	const int &fd = client.GetFd();
 
-	//　引数がない場合　例）NICK
+	// 引数がない場合 例）NICK
 	if (message.GetParams().size() < 1) {
 		SendMessage(fd, ERR_NONICKNAMEGIVEN, 0);
-		return ;
+		return;
 	}
 
 	std::string const OldNick = client.GetNickname();
 	std::string const NewNick = message.GetParams()[0];
 
 	// ニックネームのサイズが9文字以下かどうかを確認
-	if (!NickSize(NewNick))
+	if (!NickSize(NewNick)) {
 		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
+		return; // 処理を終了
+	}
 
-		// ニックネームがすでに設定されているかどうかを確認
-	else if (NickAlreadySet(NewNick, map_nick_fd)) {
-		client.SetIsWelcome(false);
+	// ニックネームがすでに設定されているかどうかを確認
+	if (NickAlreadySet(NewNick, map_nick_fd)) {
 		SendMessage(fd, ERR_NICKNAMEINUSE(OldNick, NewNick), 0);
+		return; // 処理を終了
 	}
 
-		// 古いニックネームを削除し、新しいニックネームを追加
-	else {
-		map_nick_fd.erase(OldNick);
-		map_nick_fd[NewNick] = fd;
+	// 古いニックネームを削除し、新しいニックネームを追加
+	map_nick_fd.erase(OldNick);
+	map_nick_fd[NewNick] = fd;
 
-		// チャンネルのオペレータリストを更新
-		std::map<std::string, Channel> &channels = server_channels;
-		std::map<std::string, Channel>::iterator it = channels.begin();
-		for (; it != channels.end(); it++) {
-			if (it->second.IsOperator(OldNick)) {
-				it->second.RmUserFromOperator(OldNick);
-				it->second.AddUserAsO(client);
-			}
+	// チャンネルのオペレータリストを更新
+	for (std::map<std::string, Channel>::iterator it = server_channels.begin(); it != server_channels.end(); it++) {
+		if (it->second.IsOperator(OldNick)) {
+			it->second.RmUserFromOperator(OldNick);
+			it->second.AddUserAsO(client);
 		}
-
-		// ニックネームを設定
-		client.SetIsNick();
-		client.SetNickname(NewNick);
-		server->AddClient(NewNick, &client);
-
-		// ニックネーム変更メッセージを送信
-		SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
-
-		// NICKとUSERコマンドの両方が設定されている場合, Welcomeメッセージを送信
-		if (client.GetIsNick() && client.GetIsUserSet() && !client.GetIsWelcome())
-			client.SetIsWelcome(true);
 	}
+
+	// ニックネームを設定
+	client.SetIsNick();
+	client.SetNickname(NewNick);
+	server->AddClient(NewNick, &client);
+
+	// クライアントが認証済みかどうかに関わらず、クライアントの認証状態を設定
+	client.SetIsAuthenticated();
 }
+
 
 /* ニックネームのサイズが9文字以下かどうかを確認する関数
  * 引数1 -> ニックネーム

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -24,7 +24,7 @@ void Command::NICK(Client &client, Server *server,std::map<std::string, int> &ma
 		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
 
 		// ニックネームがすでに設定されているかどうかを確認
-	else if (NickAlreadySet(NewNick, map_nick_fd) == true) {
+	else if (NickAlreadySet(NewNick, map_nick_fd)) {
 		client.SetIsWelcome(false);
 		SendMessage(fd, ERR_NICKNAMEINUSE(OldNick, NewNick), 0);
 	}

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -54,13 +54,8 @@ void Command::NICK(Client &client, Server *server,std::map<std::string, int> &ma
 			SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
 
 		// NICKとUSERコマンドの両方が設定されている場合, Welcomeメッセージを送信
-		if (client.GetIsNick() && client.GetIsUserSet()) {
+		if (client.GetIsNick() && client.GetIsUserSet())
 			client.SetIsWelcome(true);
-			SendMessage(fd, RPL_WELCOME(NewNick), 0);
-			SendMessage(fd, RPL_YOURHOST(NewNick), 0);
-			SendMessage(fd, RPL_CREATED(NewNick), 0);
-			SendMessage(fd, RPL_MYINFO(NewNick), 0);
-		}
 	}
 }
 

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -38,7 +38,7 @@ void Command::NICK(Client &client, Server *server,std::map<std::string, int> &ma
 		std::map<std::string, Channel> &channels = server_channels;
 		std::map<std::string, Channel>::iterator it = channels.begin();
 		for (; it != channels.end(); it++) {
-			if (it->second.IsOperator(OldNick) == true) {
+			if (it->second.IsOperator(OldNick)) {
 				it->second.RmUserFromOperator(OldNick);
 				it->second.AddUserAsO(client);
 			}
@@ -49,12 +49,11 @@ void Command::NICK(Client &client, Server *server,std::map<std::string, int> &ma
 		client.SetNickname(NewNick);
 		server->AddClient(NewNick, &client);
 
-		// もしクライアントが認証済みの場合
-		if (client.GetIsAuthenticated())
-			SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
+		// ニックネーム変更メッセージを送信
+		SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
 
 		// NICKとUSERコマンドの両方が設定されている場合, Welcomeメッセージを送信
-		if (client.GetIsNick() && client.GetIsUserSet())
+		if (client.GetIsNick() && client.GetIsUserSet() && !client.GetIsWelcome())
 			client.SetIsWelcome(true);
 	}
 }

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -2,6 +2,7 @@
 
 bool NickSize(std::string const &nickname);
 bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_nick_fd);
+bool NickValidCharacters(std::string const &nickname);
 
 /* NICKコマンドの処理を行う関数
  * 引数1 -> クライアント
@@ -24,6 +25,12 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
 		return; // 処理を終了
 	}
+
+	// ニックネームの文字セットが有効かどうかを確認
+//	if (!NickValidCharacters(NewNick)) {
+//		SendMessage(fd, ERR_ERRONEUSNICKNAME(NewNick), 0);
+//		return; // 処理を終了
+//	}
 
 	// ニックネームがすでに設定されているかどうかを確認
 	if (NickAlreadySet(NewNick, map_nick_fd)) {
@@ -71,3 +78,26 @@ bool NickSize(std::string const &nickname) {
 bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_nick_fd) {
 	return map_nick_fd[nickname] > 0;
 }
+
+// =========== irssiに繋げた時にerrorになってしまうので、一旦コメントアウトしてる。今後変更するかもしれない。========
+
+/* ニックネームに使用できない文字が含まれていないかを確認する関数
+ * 引数1 -> ニックネーム
+ * 戻り値 -> ニックネームに使用できない文字が含まれていない場合はtrue, そうでない場合はfalse */
+//bool NickValidCharacters(std::string const &nickname) {
+//	if (nickname.empty())
+//		return false;
+//
+//	// 最初の文字がアルファベットまたは特殊文字かどうかを確認
+//	char first_char = nickname[0];
+//	if (!(isalpha(first_char) || first_char == '[' || first_char == ']' || first_char == '\\' || first_char == '^' || first_char == '_' || first_char == '{' || first_char == '}' || first_char == '|'))
+//		return false;
+//
+//	// それ以降の文字が有効かどうかを確認
+//	for (std::string::const_iterator it = nickname.begin() + 1; it != nickname.end(); ++it) {
+//		char c = *it;
+//		if (!(isalpha(c) || isdigit(c) || c == '-' || c == '[' || c == ']' || c == '\\' || c == '^' || c == '_' || c == '{' || c == '}' || c == '|'))
+//			return false;
+//	}
+//	return true;
+//}

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -120,7 +120,7 @@ void Server::ExecuteCommand(int fd, const Message &message) {
 		// クライアントがニックネームを設定していない場合
 	else if (!client.GetIsWelcome() && !client.GetIsConnected() && cmd == "NICK") {
 		Command::NICK(client, this, map_nick_fd_, server_channels_, message);
-		if (client.GetIsNick())
+		if (client.GetIsNick() && client.GetIsUserSet())
 			SendWelcomeMessage(client);
 		return;
 	}

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -208,13 +208,17 @@ void Server::CloseFds() {
 /* Clientの初期設定
  1: 引数(socketfd) -> クライアントのソケットファイルディスクリプタ*/
 	void Server::SetupClient(int socketfd) {
-		// set client nickname
+		// ニックネームを設定
 		std::stringstream ss;
 		ss << "unknown" << socketfd;
+
+		// ニックネームを取得
 		const std::string nick = ss.str();
-		// create new user
+
+		// 新しいクライアントを作成
 		Client user(socketfd, nick);
-		// add user to map
+
+		// クライアントをマップに追加
 		users_[socketfd] = user;
 	}
 
@@ -224,33 +228,36 @@ void Server::CloseFds() {
 		struct sockaddr_in clientAddress;
 		socklen_t len = sizeof(clientAddress);
 
-		// accept new client
+		// 新しいクライアントを受け入れる
 		int incomingfd = accept(server_socket_fd_, (struct sockaddr *) &clientAddress, &len);
 		if (incomingfd == -1) {
 			std::cout << RED << "accept() failed" << STOP << std::endl;
 			return;
 		}
 
-		// set client socket to non-blocking
+		// non-blocking socketを設定
 		if (fcntl(incomingfd, F_SETFL, O_NONBLOCK) == -1) {
 			std::cout << RED << "fcntl() failed" << STOP << std::endl;
 			close(incomingfd);
 			return;
 		}
 
-		// initialize client
+		// 新しいクライアントの初期設定
 		SetupClient(incomingfd);
 
+		// 新しいクライアントをconnected_clientsに追加
 		Client &client = users_[incomingfd];
-		// set client IP address
+
+		// clientIpAddressを設定
 		client.SetIPAddress(inet_ntoa(clientAddress.sin_addr));
-		// add client to vector
+
+		// vectorにクライアントを追加
 		connected_clients.push_back(client);
 
 		// Client* client_p = new Client(incomingfd, client.GetNickname());
 		// AddClient(client.GetNickname(), client_p);
 
-		// call MakePoll with the new client's fd
+		// 新しいクライアントのfdをMakePollに渡す
 		MakePoll(incomingfd);
 		std::cout << GREEN << "New client <" << incomingfd << "> connected" << STOP << std::endl;
 	}


### PR DESCRIPTION
**＜やったこと＞**
1. serverとclientが繋がった際に、2回Welcomeメッセージが出てしまうのを修正
2. nicknameを更新するたびにWelcomeメッセージが出てしまうのを修正
3. nicknameを更新した際にメッセージを出力


**＜テスト内容＞**
1. `NICK`　（引数なし）
`:ft_irc 431 :No nickname given`
2. `NICK a `（適切な文字だとWelcomeメッセージ）
```
NICK a
:unknown4 NICK :a
:ft_irc 001 a :Welcome to the Internet Relay Chat Network 
:ft_irc 002 a :Your host is ft_irc, running version 1.0
:ft_irc 003 a :This server was created in C++ [Sunday, June 16, 2024]
:ft_irc 004 a :FT_IRC 1.0 contributes: oaoba yushimom stakimot 
```
3. NICKを更新（a から bにnickname変更）
```
NICK b
:a NICK :b
```


**＜相談内容＞**
・NICKコマンドの文字制約を組み込むかどうか検討中
（RFCには記載が見つからなかったため、二人にも確認してもらいたいです。）　✅
