### PR TITLE
Issue46 fix

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -62,7 +62,7 @@ public:
 	void SetIPAddress(const std::string& ipaddress);
 	void AddMessage(const std::string &message);
 
-	void SetIsNick();
+	void SetIsNick(bool flag);
 	void SetUsername(const std::string &username);
 	void SetHostname(const std::string &hostname);
 	void SetServername(const std::string &servername);

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -29,7 +29,7 @@ private:
 
 public:
 	Client();
-	Client(int fd_, const std::string &nick);
+	Client(int fd);
 	~Client();
 
 	void Parse(const std::string &message);

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -108,7 +108,6 @@ void Client::SetIsAuthenticated() {
 
 void Client::SetNickname(const std::string &nick) {
 	this->nickname_ = nick;
-	this->is_user_set_ = true;
 }
 
 void Client::SetIsWelcome(bool is_welcome) {
@@ -123,8 +122,8 @@ void Client::SetIPAddress(const std::string &ipaddress) {
 	this->ip_address_ = ipaddress;
 }
 
-void Client::SetIsNick() {
-	this->is_nickname_ = true;
+void Client::SetIsNick(bool flag) {
+	this->is_nickname_ = flag;
 }
 
 void Client::SetUsername(const std::string &username) {

--- a/srcs/client/Client.cpp
+++ b/srcs/client/Client.cpp
@@ -2,8 +2,8 @@
 
 Client::Client() : fd_(-1), is_authenticated_(false) {}
 
-Client::Client(int fd, const std::string &nick)
-	: fd_(fd), nickname_(nick), is_authenticated_(false), is_nickname_(true), is_user_set_(false) {}
+Client::Client(int fd)
+	: fd_(fd), nickname_(""), is_authenticated_(false), is_nickname_(false), is_user_set_(false) {}
 
 Client::~Client() {}
 

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -46,12 +46,9 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 	}
 
 	// ニックネームを設定
-	client.SetIsNick();
+	client.SetIsNick(true);
 	client.SetNickname(NewNick);
 	server->AddClient(NewNick, &client);
-
-	// クライアントが認証済みかどうかに関わらず、クライアントの認証状態を設定
-	client.SetIsAuthenticated();
 
 	// ニックネーム変更メッセージを生成して送信
 	SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
@@ -62,7 +59,7 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
  * 引数1 -> ニックネーム
  * 戻り値 -> ニックネームのサイズが9文字以下の場合はtrue, そうでない場合はfalse*/
 bool NickSize(std::string const &nickname) {
-	return (nickname.size() > 9) ? false : true;
+	return nickname.size() <= 9;
 }
 
 
@@ -71,5 +68,5 @@ bool NickSize(std::string const &nickname) {
  * 引数2 -> ニックネームとソケットファイルディスクリプタのマップ
  * 戻り値 -> ニックネームが設定されている場合はtrue, そうでない場合はfalse*/
 bool NickAlreadySet(std::string const &nickname, std::map<std::string, int> map_nick_fd) {
-	return map_nick_fd[nickname] > 0;
+	return map_nick_fd.find(nickname) != map_nick_fd.end();
 }

--- a/srcs/command/NICK.cpp
+++ b/srcs/command/NICK.cpp
@@ -39,7 +39,7 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 	std::map<std::string, Channel*> channels = server_channels;
 	std::map<std::string, Channel*>::iterator it = channels.begin();
 	for (; it != channels.end(); it++) {
-		if (it->second->IsOperator(OldNick) == true) {
+		if (it->second->IsOperator(OldNick)) {
 			it->second->RmUserFromOperator(OldNick);
 			it->second->AddUserAsO(client);
 		}
@@ -51,7 +51,9 @@ void Command::NICK(Client &client, Server *server, std::map<std::string, int> &m
 	server->AddClient(NewNick, &client);
 
 	// ニックネーム変更メッセージを生成して送信
-	SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
+	if (!OldNick.empty()) {
+		SendMessage(fd, RPL_NICK(OldNick, NewNick), 0);
+	}
 }
 
 

--- a/srcs/command/USER.cpp
+++ b/srcs/command/USER.cpp
@@ -10,13 +10,21 @@ void Command::USER(Client &client, const Message &message) {
 	int fd = client.GetFd();
 	std::string nickname = client.GetNickname();
 
-	if (message.GetParams().size() != 4)
+	// パラメータの数を確認し、不足している場合はエラーメッセージを送信して処理を終了
+	if (message.GetParams().size() != 4) {
 		SendMessage(fd, std::string(YELLOW) + ERR_NEEDMOREPARAMS(nickname, "USER") + std::string(STOP), 0);
-	else {
-		client.SetUsername(message.GetParams()[0]);
-		client.SetHostname(message.GetParams()[1]);
-		client.SetServername(message.GetParams()[2]);
-		client.SetRealname(message.GetParams()[3]);
+		return; // エラーメッセージ送信後、処理を終了
 	}
+
+	// クライアントのユーザー情報を設定
+	client.SetUsername(message.GetParams()[0]);
+	client.SetHostname(message.GetParams()[1]);
+	client.SetServername(message.GetParams()[2]);
+	client.SetRealname(message.GetParams()[3]);
+
+	// ユーザー情報が設定されたことを記録
+	client.SetIsUserSet(true);
+
+	// デバッグ目的の情報出力
 	std::cout << "USER: " << client.GetUsername() << " " << client.GetHostname() << " " << client.GetServername() << " " << client.GetRealname() << std::endl;
 }

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -225,15 +225,8 @@ void Server::CloseFds() {
 /* Clientの初期設定
  1: 引数(socketfd) -> クライアントのソケットファイルディスクリプタ*/
 void Server::SetupClient(int socketfd) {
-	// ニックネームを設定
-	std::stringstream ss;
-	ss << "unknown" << socketfd;
-
-	// ニックネームを取得
-	const std::string nick = ss.str();
-
 	// 新しいクライアントを作成
-	Client user(socketfd, nick);
+	Client user(socketfd);
 
 	// クライアントをマップに追加
 	users_[socketfd] = user;


### PR DESCRIPTION
＜修正箇所＞
・welcomeメッセージの出力をNICKとUSERコマンドの登録が終わった後に来るようにした
・コマンドの関数いく前に弾かれてしまっていた問題を解決

**tes方法**
1. NICK, USER両方を入力する（入力する順番はどちらが先でも問題ない）
2. 両方が入力された時にのみWelcomeメッセージを出力し、clientと接続ができる

(例)
1. NICK nickname (NICKコマンド使用)　→このままではWelcomeメッセージ出ない
2. USER a b c d (USERコマンド使用)　→ここでWelcomeメッセージが出るはず。
```
:ft_irc 001 a :Welcome to the Internet Relay Chat Network 
:ft_irc 002 a :Your host is ft_irc, running version 1.0
:ft_irc 003 a :This server was created in C++ [Sunday, June 16, 2024]
:ft_irc 004 a :FT_IRC 1.0 contributes: oaoba yushimom stakimot 
```

**接続の流れ**
1. NICKとUSERコマンドが送信される:
・クライアントはまずNICKコマンドでニックネームを指定。
・次にUSERコマンドでユーザー情報を指定。

3. NICKとUSERが両方受信されると、サーバーはクライアントを認証する:
・サーバーはNICKとUSERの両方が受信された時点で、クライアントを正式に接続済みと見なし、Welcomeメッセージを送信する。

4. Welcomeメッセージ:
クライアントが正式に接続されたことを通知するメッセージで、通常は以下のような内容になる。
`:server_name 001 <nick> :Welcome to the Internet Relay Chat Network <nick>`


