### PR TITLE
45 mode fix

### DIFF
--- a/includes/Command.hpp
+++ b/includes/Command.hpp
@@ -61,6 +61,10 @@ class Message;
 #define ERR_BADCHANNELKEY(nick, ch_name)  ":ft_irc 475 " + nick + " " + ch_name + " :Cannot join channel (+k)\r\n"
 #define ERR_INVITEONLYCHAN(nick, ch_name) ":ft_irc 473  " + nick + " " + ch_name + " :Cannot join channel (+l)\r\n"
 
+//チャンネルMODEエラーメッセージ
+#define ERR_LIMITVALUEMINUS(nick, ch_name) ":ft_irc 472 " + nick + " -l :is an unknown mode character to me\r\n"
+#define ERR_LIMITVALUEOVER(nick, ch_name) ":ft_irc 461 " + nick + " MODE :Not enough parameters\r\n"
+
 // パスワードエラーメッセージ
 #define PASS_ERROR(host) "ERROR :Closing Link: " + host + "(Bad Password)\r\n"
 

--- a/includes/Utils.hpp
+++ b/includes/Utils.hpp
@@ -4,13 +4,21 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <sstream>
 #include <map>
 #include "Channel.hpp"
 
 class Channel;
-
 const std::vector<std::string> SplitComma(const std::string &param);
 bool FindChannelForServer(std::map<std::string, Channel*> &channels, const std::string &target);
 // void rtrim(std::string& str);
+long long int string_to_llint(const std::string& str);
+
+template <typename T>
+std::string change_string(T value) {
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
 
 #endif

--- a/srcs/channel/Channel.cpp
+++ b/srcs/channel/Channel.cpp
@@ -88,6 +88,8 @@ void Channel::SetModeKey(const bool key)
 
 void Channel::SetModeLimit(long int user_limit)
 {
+    // std::cout << "Channnel.cpp limit: " << user_limit << std::endl;
+    this->mode_.SetLimit(user_limit);
     this->limit_ = user_limit;
 }
 

--- a/srcs/channel/ChannelMode.cpp
+++ b/srcs/channel/ChannelMode.cpp
@@ -1,6 +1,6 @@
 #include "Mode.hpp"
 
-Mode::Mode():invite_(false), topic_(false), key_(false), limit_(__LONG_MAX__)
+Mode::Mode():invite_(false), topic_(false), key_(false), limit_(0)
 {
 }
 

--- a/srcs/command/MODE.cpp
+++ b/srcs/command/MODE.cpp
@@ -154,11 +154,13 @@ else if(mode_option == "-k"){
 		}
 		try{
 			std::string limit = message.GetParams()[2];
-			if (string_to_llint(limit) < 0){
+			//リミットが1以下の場合
+			if (string_to_llint(limit) < 1){
 				msg_to_c = ERR_LIMITVALUEMINUS(client.GetNickname(), ch_name);
 				SendMessage(client.GetFd(), msg_to_c, 0);
 				return ;
 			}
+			//リミットがLONG_MAXを超える場合
 			if (string_to_llint(limit) > LONG_MAX){
 				msg_to_c = ERR_LIMITVALUEOVER(client.GetNickname(), ch_name);
 				SendMessage(client.GetFd(), msg_to_c, 0);

--- a/srcs/command/MODE.cpp
+++ b/srcs/command/MODE.cpp
@@ -51,7 +51,7 @@ void Command::MODE(Client &client, Server *server, const Message &message)
 			msg_to_c += "k";
 		}
 		if(ch->GetModeIsLimit())
-		msg_to_c += " " + std::to_string(ch->GetModeLimit());
+		msg_to_c += " " + change_string(ch->GetModeLimit());
 		msg_to_c += "\r\n";
 		SendMessage(client.GetFd(), msg_to_c, 0);
 		return ;
@@ -154,8 +154,19 @@ else if(mode_option == "-k"){
 		}
 		try{
 			std::string limit = message.GetParams()[2];
+			if (string_to_llint(limit) < 0){
+				msg_to_c = ERR_LIMITVALUEMINUS(client.GetNickname(), ch_name);
+				SendMessage(client.GetFd(), msg_to_c, 0);
+				return ;
+			}
+			if (string_to_llint(limit) > LONG_MAX){
+				msg_to_c = ERR_LIMITVALUEOVER(client.GetNickname(), ch_name);
+				SendMessage(client.GetFd(), msg_to_c, 0);
+				return ;
+			}
 			ch->SetModeIsLimit(true);
-			ch->SetModeLimit(std::stoi(limit));
+			ch->SetModeLimit(string_to_llint(limit));
+			std::cout << "ch->limit:" << ch->GetModeLimit() << std::endl;
 			msg_to_all = ":nick!" + client.GetNickname() + client.GetHostname() + " MODE " + ch_name + " +l " + limit + "\r\n";
 			ch->SendMsgToAll(msg_to_all, &client);
 		}catch(const std::invalid_argument& e){

--- a/srcs/utils/change_string.cpp
+++ b/srcs/utils/change_string.cpp
@@ -1,8 +1,0 @@
-// #include "Utils.hpp"
-
-// template <typename T>
-// std::string change_string(T value) {
-//     std::ostringstream oss;
-//     oss << value;
-//     return oss.str();
-// }

--- a/srcs/utils/change_string.cpp
+++ b/srcs/utils/change_string.cpp
@@ -1,0 +1,8 @@
+// #include "Utils.hpp"
+
+// template <typename T>
+// std::string change_string(T value) {
+//     std::ostringstream oss;
+//     oss << value;
+//     return oss.str();
+// }

--- a/srcs/utils/string_to_int.cpp
+++ b/srcs/utils/string_to_int.cpp
@@ -1,0 +1,14 @@
+#include "Utils.hpp"
+
+long long int string_to_llint(const std::string& str) {
+    std::istringstream iss(str);
+    long long int num;
+    iss >> num;
+
+    // 変換に失敗した場合は例外をスローするか、適切なエラーハンドリングを行う必要があります。
+    if (iss.fail()) {
+        throw std::invalid_argument("Invalid input string for conversion to integer");
+    }
+
+    return num;
+}


### PR DESCRIPTION
MODEでc++11を使っちゃってたのを修正
MODEでリミットを設定する時のエラーを対応（マイナス入力時と、long int max以上の値入力時）

テスト方法
・チャンネルに参加
`JOIN #ch`

・チャンネルにリミットを設定（オペレーター権限があるuserのみ設定可能）
`MODE #ch +l <リミット数>`
例：`MODE #ch +l 5`

リミット数がマイナス値orLONG INT MAX以上だとエラーが出力される